### PR TITLE
Configure Prettier and format source

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+build
+coverage

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 80
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,6 @@
-import { dirname } from "path";
-import { fileURLToPath } from "url";
-import { FlatCompat } from "@eslint/eslintrc";
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { FlatCompat } from '@eslint/eslintrc';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -10,7 +10,7 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
+  ...compat.extends('next/core-web-vitals', 'next/typescript'),
 ];
 
 export default eslintConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,4 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   /* config options here */

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack -p 4000",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "format": "prettier --write ."
   },
   "dependencies": {
     "jose": "^6.0.11",
@@ -28,6 +29,7 @@
     "eslint-config-next": "15.3.3",
     "postcss": "^8.5.4",
     "tailwindcss": "^4.1.8",
-    "typescript": "^5"
+    "typescript": "^5",
+    "prettier": "^3.2.5"
   }
 }

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,5 +1,5 @@
 const config = {
-  plugins: ["@tailwindcss/postcss"],
+  plugins: ['@tailwindcss/postcss'],
 };
 
 export default config;

--- a/src/app/api/lab/mock.ts
+++ b/src/app/api/lab/mock.ts
@@ -5,11 +5,10 @@ import type { VirtualLabViewModel } from '@app/types/lab/viewModels';
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<VirtualLabViewModel>
+  res: NextApiResponse<VirtualLabViewModel>,
 ) {
   res.status(200).json(dolphinLabMock);
 }
-
 
 export const dolphinLabMock: VirtualLabViewModel = {
   name: 'Dolphin watching Lab',

--- a/src/app/api/lab/mock/route.ts
+++ b/src/app/api/lab/mock/route.ts
@@ -7,7 +7,6 @@ export async function GET(): Promise<NextResponse<VirtualLabViewModel>> {
   return NextResponse.json(dolphinLabMock);
 }
 
-
 export const dolphinLabMock: VirtualLabViewModel = {
   name: 'Dolphin watching Lab',
   alias: 'DLPH-01',

--- a/src/app/components/AssignedUsers.tsx
+++ b/src/app/components/AssignedUsers.tsx
@@ -1,12 +1,16 @@
 // components/Lab/AssignedUsers.tsx
 
-"use client";
+'use client';
 
-import { use, useContext, useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
-import { AuthContext } from "@app/context/AuthContext";
-import { getAllRoles, getRoleByCode, initializeRoleCache } from "@app/lib/roles";
-import { API_BASE_URL } from "@app/constants/config";
+import { use, useContext, useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { AuthContext } from '@app/context/AuthContext';
+import {
+  getAllRoles,
+  getRoleByCode,
+  initializeRoleCache,
+} from '@app/lib/roles';
+import { API_BASE_URL } from '@app/constants/config';
 
 type AssignedUser = {
   userId: string;
@@ -23,13 +27,13 @@ type Props = {
 
 export default function AssignedUsers({ users, labId }: Props) {
   const { user } = useContext(AuthContext);
-  const isAdmin = user?.roles.includes("vre_admin");
+  const isAdmin = user?.roles.includes('vre_admin');
 
   const [showModal, setShowModal] = useState(false);
   const [availableUsers, setAvailableUsers] = useState<any[]>([]);
   const [availableRoles, setAvailableRoles] = useState<any[]>([]);
-  const [selectedUserId, setSelectedUserId] = useState("");
-  const [selectedRole, setSelectedRole] = useState<string>("");
+  const [selectedUserId, setSelectedUserId] = useState('');
+  const [selectedRole, setSelectedRole] = useState<string>('');
 
   useEffect(() => {
     if (showModal) {
@@ -48,7 +52,9 @@ export default function AssignedUsers({ users, labId }: Props) {
     try {
       const userData = users.find((u) => u.userId === selectedUserId);
       const existingRoles = userData?.role_codes || [];
-      const updatedRoles = Array.from(new Set([...existingRoles, selectedRole]));
+      const updatedRoles = Array.from(
+        new Set([...existingRoles, selectedRole]),
+      );
 
       const dto = [
         {
@@ -58,17 +64,17 @@ export default function AssignedUsers({ users, labId }: Props) {
       ];
 
       const res = await fetch(`${API_BASE_URL}/lab/${labId}/assign-users`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(dto),
       });
 
-      if (!res.ok) throw new Error("Assignment failed");
-      alert("User assigned successfully.");
+      if (!res.ok) throw new Error('Assignment failed');
+      alert('User assigned successfully.');
       setShowModal(false);
       location.reload();
     } catch (error) {
-      alert("Error assigning user.");
+      alert('Error assigning user.');
       console.error(error);
     }
   };
@@ -91,11 +97,11 @@ export default function AssignedUsers({ users, labId }: Props) {
         {users.map((user, index) => (
           <li key={index} className="py-2">
             <div className="text-sm text-gray-800 dark:text-gray-100 font-medium">
-              {user.name || "Unknown User"} — {user.email || "No Email"}
+              {user.name || 'Unknown User'} — {user.email || 'No Email'}
             </div>
             <div className="flex flex-wrap gap-2 mt-1">
               {(user.role_codes || []).map((code, idx) => {
-                const role = getRoleByCode(code.replace(/\[|\]/g, ""));
+                const role = getRoleByCode(code.replace(/\[|\]/g, ''));
                 return (
                   <span
                     key={idx}
@@ -108,7 +114,10 @@ export default function AssignedUsers({ users, labId }: Props) {
               })}
             </div>
             <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-              Assigned at: {user.assignedAt ? new Date(user.assignedAt).toLocaleString() : "Unknown"}
+              Assigned at:{' '}
+              {user.assignedAt
+                ? new Date(user.assignedAt).toLocaleString()
+                : 'Unknown'}
             </div>
           </li>
         ))}
@@ -118,7 +127,9 @@ export default function AssignedUsers({ users, labId }: Props) {
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
           <div className="bg-white dark:bg-gray-800 p-6 rounded shadow-xl w-full max-w-md">
             <div className="flex justify-between items-center mb-4">
-              <h3 className="text-lg font-semibold">Assign User to Virtual Lab</h3>
+              <h3 className="text-lg font-semibold">
+                Assign User to Virtual Lab
+              </h3>
               <button
                 className="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
                 onClick={() => setShowModal(false)}
@@ -128,7 +139,9 @@ export default function AssignedUsers({ users, labId }: Props) {
             </div>
             <div className="space-y-4">
               <div>
-                <label className="block text-sm font-medium mb-1">Select User</label>
+                <label className="block text-sm font-medium mb-1">
+                  Select User
+                </label>
                 <select
                   value={selectedUserId}
                   onChange={(e) => setSelectedUserId(e.target.value)}
@@ -137,13 +150,15 @@ export default function AssignedUsers({ users, labId }: Props) {
                   <option value="">Select a user</option>
                   {availableUsers.map((u) => (
                     <option key={u.id} value={u.id}>
-                      {u.name || u.reference_id} — {u.email || "No Email"}
+                      {u.name || u.reference_id} — {u.email || 'No Email'}
                     </option>
                   ))}
                 </select>
               </div>
               <div>
-                <label className="block text-sm font-medium mb-1">Select Role</label>
+                <label className="block text-sm font-medium mb-1">
+                  Select Role
+                </label>
                 <select
                   className="w-full p-2 border rounded bg-white dark:bg-gray-700 dark:text-white"
                   value={selectedRole}

--- a/src/app/components/ExitConditions/Card.tsx
+++ b/src/app/components/ExitConditions/Card.tsx
@@ -1,24 +1,30 @@
-"use client";
+'use client';
 
-import { useState } from "react";
-import { API_BASE_URL } from "@app/constants/config";
-import { ExitConditionCardProps } from "@app/components/ExitConditions/types";
-import { exitConditionLabels, exitConditionStatuses } from "@app/constants/exitCondition";
+import { useState } from 'react';
+import { API_BASE_URL } from '@app/constants/config';
+import { ExitConditionCardProps } from '@app/components/ExitConditions/types';
+import {
+  exitConditionLabels,
+  exitConditionStatuses,
+} from '@app/constants/exitCondition';
 
-export default function ExitConditionCard({ cond, labId, userRoles }: ExitConditionCardProps) {
-  const isCoordinator = userRoles.includes("CRD");
+export default function ExitConditionCard({
+  cond,
+  labId,
+  userRoles,
+}: ExitConditionCardProps) {
+  const isCoordinator = userRoles.includes('CRD');
 
   const [showEditModal, setShowEditModal] = useState(false);
   const [showCommentModal, setShowCommentModal] = useState(false);
 
-
   // 🔁 Make local display state
   const [status, setStatus] = useState(cond.status);
-  const [discussionUrl, setDiscussionUrl] = useState(cond.discussion_url || "");
+  const [discussionUrl, setDiscussionUrl] = useState(cond.discussion_url || '');
   const fulfilled = status === 300;
 
   const [selectedStatus, setSelectedStatus] = useState(cond.status);
-  const [comment, setComment] = useState("");
+  const [comment, setComment] = useState('');
 
   const label = exitConditionLabels[cond.type] ?? `Type ${cond.type}`;
   const statusLabel = exitConditionStatuses[status] ?? status;
@@ -28,25 +34,25 @@ export default function ExitConditionCard({ cond, labId, userRoles }: ExitCondit
       const res = await fetch(
         `${API_BASE_URL}/lab/${labId}/exit_condition/${cond.id}/update`,
         {
-          method: "POST",
+          method: 'POST',
           headers: {
-            "Content-Type": "application/json",
+            'Content-Type': 'application/json',
           },
           body: JSON.stringify({
             status: selectedStatus,
             comments: comment,
             discussion_url: discussionUrl,
           }),
-        }
+        },
       );
 
-      if (!res.ok) throw new Error("Failed to update exit condition");
+      if (!res.ok) throw new Error('Failed to update exit condition');
 
       setStatus(selectedStatus);
       setShowEditModal(false);
     } catch (error) {
-      console.error("Update failed", error);
-      alert("An error occurred while updating.");
+      console.error('Update failed', error);
+      alert('An error occurred while updating.');
     }
   };
 
@@ -54,23 +60,27 @@ export default function ExitConditionCard({ cond, labId, userRoles }: ExitCondit
     <div
       className={`border rounded-lg p-3 text-sm flex flex-col gap-2 ${
         fulfilled
-          ? "border-green-300 bg-green-50 dark:bg-green-900/30"
-          : "border-orange-300 bg-orange-50 dark:bg-orange-900/20"
+          ? 'border-green-300 bg-green-50 dark:bg-green-900/30'
+          : 'border-orange-300 bg-orange-50 dark:bg-orange-900/20'
       }`}
     >
       <div className="flex items-center justify-between gap-4">
-      <div className="flex flex-col sm:flex-row sm:items-center sm:gap-2 text-sm font-medium">
-        <span className="text-blue-700 dark:text-blue-300">EC{cond.type}</span>
-        <span className="text-gray-800 dark:text-gray-100">{label}</span>
+        <div className="flex flex-col sm:flex-row sm:items-center sm:gap-2 text-sm font-medium">
+          <span className="text-blue-700 dark:text-blue-300">
+            EC{cond.type}
+          </span>
+          <span className="text-gray-800 dark:text-gray-100">{label}</span>
+        </div>
+        <span
+          className={`text-xs font-semibold ${
+            fulfilled
+              ? 'text-green-700 dark:text-green-400'
+              : 'text-orange-700 dark:text-orange-400'
+          }`}
+        >
+          {statusLabel}
+        </span>
       </div>
-      <span
-        className={`text-xs font-semibold ${
-          fulfilled ? "text-green-700 dark:text-green-400" : "text-orange-700 dark:text-orange-400"
-        }`}
-      >
-        {statusLabel}
-      </span>
-    </div>
       <div className="flex justify-between items-center text-xs">
         <div className="flex gap-4">
           {cond.tooltip_url && (
@@ -86,13 +96,13 @@ export default function ExitConditionCard({ cond, labId, userRoles }: ExitCondit
             </a>
           )}
           {cond.comments && (
-                  <button
-                  onClick={() => setShowCommentModal(true)}
-                  className="flex items-center gap-1 text-sm text-indigo-600 hover:underline"
-                  title="View comment"
-                >
-                  📝 <span className="hidden sm:inline">Comment</span>
-                </button>
+            <button
+              onClick={() => setShowCommentModal(true)}
+              className="flex items-center gap-1 text-sm text-indigo-600 hover:underline"
+              title="View comment"
+            >
+              📝 <span className="hidden sm:inline">Comment</span>
+            </button>
           )}
 
           {discussionUrl && (
@@ -106,7 +116,6 @@ export default function ExitConditionCard({ cond, labId, userRoles }: ExitCondit
               💬 <span className="hidden sm:inline">Discussion</span>
             </a>
           )}
-          
         </div>
 
         {isCoordinator && (
@@ -119,25 +128,24 @@ export default function ExitConditionCard({ cond, labId, userRoles }: ExitCondit
         )}
       </div>
 
-        {showCommentModal && (
-          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-            <div className="bg-white dark:bg-gray-800 p-4 rounded-lg shadow-xl max-w-sm w-full">
-              <div className="flex justify-between items-center mb-2">
-                <h4 className="font-semibold text-sm">Exit Condition Comment</h4>
-                <button
-                  onClick={() => setShowCommentModal(false)}
-                  className="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
-                >
-                  ✕
-                </button>
-              </div>
-              <p className="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap">
-                {cond.comments}
-              </p>
+      {showCommentModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="bg-white dark:bg-gray-800 p-4 rounded-lg shadow-xl max-w-sm w-full">
+            <div className="flex justify-between items-center mb-2">
+              <h4 className="font-semibold text-sm">Exit Condition Comment</h4>
+              <button
+                onClick={() => setShowCommentModal(false)}
+                className="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
+              >
+                ✕
+              </button>
             </div>
+            <p className="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap">
+              {cond.comments}
+            </p>
           </div>
-        )}
-
+        </div>
+      )}
 
       {showEditModal && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
@@ -154,22 +162,28 @@ export default function ExitConditionCard({ cond, labId, userRoles }: ExitCondit
 
             <div className="space-y-4">
               <div>
-                <label className="block text-sm font-medium mb-1">Update Status</label>
+                <label className="block text-sm font-medium mb-1">
+                  Update Status
+                </label>
                 <select
                   className="w-full p-2 border rounded bg-white dark:bg-gray-700 dark:text-white"
                   value={selectedStatus}
                   onChange={(e) => setSelectedStatus(Number(e.target.value))}
                 >
-                  {Object.entries(exitConditionStatuses).map(([code, label]) => (
-                    <option key={code} value={code}>
-                      {label}
-                    </option>
-                  ))}
+                  {Object.entries(exitConditionStatuses).map(
+                    ([code, label]) => (
+                      <option key={code} value={code}>
+                        {label}
+                      </option>
+                    ),
+                  )}
                 </select>
               </div>
 
               <div>
-                <label className="block text-sm font-medium mb-1">Comment</label>
+                <label className="block text-sm font-medium mb-1">
+                  Comment
+                </label>
                 <textarea
                   rows={3}
                   className="w-full p-2 border rounded bg-white dark:bg-gray-700 dark:text-white"
@@ -180,7 +194,9 @@ export default function ExitConditionCard({ cond, labId, userRoles }: ExitCondit
               </div>
 
               <div>
-                <label className="block text-sm font-medium mb-1">Discussion URL</label>
+                <label className="block text-sm font-medium mb-1">
+                  Discussion URL
+                </label>
                 <input
                   type="url"
                   className="w-full p-2 border rounded bg-white dark:bg-gray-700 dark:text-white"

--- a/src/app/components/LabView.tsx
+++ b/src/app/components/LabView.tsx
@@ -1,15 +1,14 @@
-"use client";
+'use client';
 
-import { useContext, useMemo } from "react";
-import { VirtualLabViewModel } from "@app/types/lab/viewModels";
-import { ExitCondition } from "@app/components/ExitConditions/types";
-import { AuthContext } from "@app/context/AuthContext";
+import { useContext, useMemo } from 'react';
+import { VirtualLabViewModel } from '@app/types/lab/viewModels';
+import { ExitCondition } from '@app/components/ExitConditions/types';
+import { AuthContext } from '@app/context/AuthContext';
 
 //Components
-import ExitConditionCard from "@app/components/ExitConditions/Card";
-import AssignedUsers from "@app/components/AssignedUsers"
-import MaturityProgress from "@app/components/MaturityProgress";
-
+import ExitConditionCard from '@app/components/ExitConditions/Card';
+import AssignedUsers from '@app/components/AssignedUsers';
+import MaturityProgress from '@app/components/MaturityProgress';
 
 type Props = {
   lab: VirtualLabViewModel;
@@ -18,66 +17,71 @@ type Props = {
 export default function LabView({ lab }: Props) {
   const { user } = useContext(AuthContext);
 
-
   const roles = useMemo(() => {
-      const keycloakRoles = user?.roles ?? [];
-      const labUser = lab.assignedUsers.find(u => u.reference_id === user?.id);
-      console.log('User', {user, lab, labUser});
-      const labRoles = labUser?.role_codes ?? [];
-      return Array.from(new Set([...keycloakRoles, ...labRoles]));
+    const keycloakRoles = user?.roles ?? [];
+    const labUser = lab.assignedUsers.find((u) => u.reference_id === user?.id);
+    console.log('User', { user, lab, labUser });
+    const labRoles = labUser?.role_codes ?? [];
+    return Array.from(new Set([...keycloakRoles, ...labRoles]));
   }, [user?.id, user?.roles, lab.assignedUsers]);
-
 
   return (
     <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)] bg-[color:var(--background)] text-[color:var(--foreground)]">
       <main className="flex flex-col gap-10 row-start-2 items-center sm:items-start max-w-3xl w-full">
-
         <section className="w-full space-y-2">
-  <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-    <div className="flex-1">
-      <h1 className="text-3xl font-bold text-gray-900 dark:text-white">{lab.name}</h1>
-      <div className="mt-1">
-        <span className="inline-block bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-200 text-xs font-medium px-3 py-1 rounded-full">
-          Alias: {lab.alias}
-        </span>
-      </div>
-    </div>
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+            <div className="flex-1">
+              <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+                {lab.name}
+              </h1>
+              <div className="mt-1">
+                <span className="inline-block bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-200 text-xs font-medium px-3 py-1 rounded-full">
+                  Alias: {lab.alias}
+                </span>
+              </div>
+            </div>
 
-    <div className="flex gap-2">
-      <a
-        href={`https://staging.demo.naavre.net/vreapp/vlabs/${lab.alias}`}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="px-4 py-2 text-sm font-semibold bg-green-600 text-white rounded hover:bg-green-700 transition"
-      >
-        Open in NaaVRE
-      </a>
-      
-    </div>
-  </div>
-</section>
-
+            <div className="flex gap-2">
+              <a
+                href={`https://staging.demo.naavre.net/vreapp/vlabs/${lab.alias}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="px-4 py-2 text-sm font-semibold bg-green-600 text-white rounded hover:bg-green-700 transition"
+              >
+                Open in NaaVRE
+              </a>
+            </div>
+          </div>
+        </section>
 
         <MaturityProgress
-            roles={roles}
-            labId={lab.id}
-            level={lab.maturityLevel}
-            levelState={lab.levelState}
-            totalConditions={lab.exitConditions.length}
-            fulfilledConditions={lab.exitConditions.filter((c) => c.fulfilled).length}
-          />
+          roles={roles}
+          labId={lab.id}
+          level={lab.maturityLevel}
+          levelState={lab.levelState}
+          totalConditions={lab.exitConditions.length}
+          fulfilledConditions={
+            lab.exitConditions.filter((c) => c.fulfilled).length
+          }
+        />
 
         {/* Exit Conditions */}
         <section className="space-y-4 w-full">
-          <h2 className="text-lg font-semibold">Exit Conditions <a
-        href="https://naavre.net/docs/readiness_levels/"
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-sm text-blue-600 hover:underline self-center"
-      >
-        ⓘ
-      </a></h2> 
-          <p>These Conditions have to be satisfied to progress the VL to the next maturity level.</p> 
+          <h2 className="text-lg font-semibold">
+            Exit Conditions{' '}
+            <a
+              href="https://naavre.net/docs/readiness_levels/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-blue-600 hover:underline self-center"
+            >
+              ⓘ
+            </a>
+          </h2>
+          <p>
+            These Conditions have to be satisfied to progress the VL to the next
+            maturity level.
+          </p>
 
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             {lab.exitConditions.map((cond: ExitCondition) => (
@@ -86,30 +90,29 @@ export default function LabView({ lab }: Props) {
                 cond={cond}
                 userRoles={roles}
                 labId={lab.id}
-                onUpdateClick={(c) => console.log("Update requested for", c)}
+                onUpdateClick={(c) => console.log('Update requested for', c)}
               />
             ))}
           </div>
 
-            
-              <details className="bg-gray-50 dark:bg-gray-800 rounded p-4 mt-4 text-sm">
-        <summary className="cursor-pointer font-medium text-blue-700 dark:text-blue-300 mb-2">
-          What do the statuses mean for the Exit Conditions?
-        </summary>
-        <p className="mb-2">Each lab level status reflects a stage in the evaluation lifecycle:</p>
-        <img src="/images/exitCondition_kpi.svg" alt="Maturity level flow" className="mt-4 rounded border" />
-
-      </details>
-
-    
+          <details className="bg-gray-50 dark:bg-gray-800 rounded p-4 mt-4 text-sm">
+            <summary className="cursor-pointer font-medium text-blue-700 dark:text-blue-300 mb-2">
+              What do the statuses mean for the Exit Conditions?
+            </summary>
+            <p className="mb-2">
+              Each lab level status reflects a stage in the evaluation
+              lifecycle:
+            </p>
+            <img
+              src="/images/exitCondition_kpi.svg"
+              alt="Maturity level flow"
+              className="mt-4 rounded border"
+            />
+          </details>
         </section>
 
-       <AssignedUsers users={lab.assignedUsers} labId={lab.id} />
-
+        <AssignedUsers users={lab.assignedUsers} labId={lab.id} />
       </main>
-
-
-
 
       <footer className="row-start-3 text-xs text-gray-400 dark:text-gray-500 text-center">
         Data rendered for: {lab.alias}

--- a/src/app/components/MaturityProgress.tsx
+++ b/src/app/components/MaturityProgress.tsx
@@ -1,10 +1,10 @@
 // components/Lab/MaturityProgress.tsx
 
-"use client";
+'use client';
 
-import React, { useState } from "react";
-import { getRoleByCode } from "@app/lib/roles";
-import { API_BASE_URL } from "@app/constants/config";
+import React, { useState } from 'react';
+import { getRoleByCode } from '@app/lib/roles';
+import { API_BASE_URL } from '@app/constants/config';
 
 interface Props {
   roles: string[];
@@ -40,28 +40,30 @@ export default function MaturityProgress({
   const [showHelpModal, setShowHelpModal] = useState(false);
   const [selectedStatus, setSelectedStatus] = useState(levelState);
 
-  const percentage = totalConditions > 0 ? Math.round((fulfilledConditions / totalConditions) * 100) : 0;
+  const percentage =
+    totalConditions > 0
+      ? Math.round((fulfilledConditions / totalConditions) * 100)
+      : 0;
 
   const canRequestEvaluation =
-    levelState === 100 && (roles.includes("GLU") || roles.includes("VLD"));
+    levelState === 100 && (roles.includes('GLU') || roles.includes('VLD'));
   const canRequestReevaluation =
-    levelState === 202 && (roles.includes("GLU") || roles.includes("VLD"));
+    levelState === 202 && (roles.includes('GLU') || roles.includes('VLD'));
   const canUpdateStatus =
-    [100, 101, 200, 201, 203].includes(levelState) && roles.includes("CRD");
+    [100, 101, 200, 201, 203].includes(levelState) && roles.includes('CRD');
 
   const updateLevel = async (newLevel: number, state: number) => {
     const res = await fetch(`${API_BASE_URL}/lab/${labId}/update_level`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ level: newLevel, state }),
     });
 
     if (!res.ok) {
-        const errorData = await res.json();
-        alert(`Update failed: ${errorData.error || 'Unknown error'}`);
-    }else{
-
-        location.reload();
+      const errorData = await res.json();
+      alert(`Update failed: ${errorData.error || 'Unknown error'}`);
+    } else {
+      location.reload();
     }
   };
 
@@ -70,20 +72,28 @@ export default function MaturityProgress({
       {/* LEFT: Lab Level Info */}
       <div className="space-y-4">
         <div className="flex items-center gap-3">
-          <span className="text-2xl font-bold text-white bg-blue-600 px-3 py-1 rounded-full">L{level}</span>
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Current Maturity Level</h2>
+          <span className="text-2xl font-bold text-white bg-blue-600 px-3 py-1 rounded-full">
+            L{level}
+          </span>
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+            Current Maturity Level
+          </h2>
         </div>
 
         <p className="text-sm text-gray-600 dark:text-gray-400">
-          Status: <strong>{LabLevelStatuses[levelState] || "Unknown"}</strong>
+          Status: <strong>{LabLevelStatuses[levelState] || 'Unknown'}</strong>
         </p>
 
         <div>
           <div className="text-sm mb-1 text-gray-600 dark:text-gray-400">
-            Exit Condition Completion: {fulfilledConditions}/{totalConditions} ({percentage}%)
+            Exit Condition Completion: {fulfilledConditions}/{totalConditions} (
+            {percentage}%)
           </div>
           <div className="w-full bg-gray-200 dark:bg-gray-700 h-3 rounded-full overflow-hidden">
-            <div className="bg-green-500 h-full transition-all duration-500" style={{ width: `${percentage}%` }} />
+            <div
+              className="bg-green-500 h-full transition-all duration-500"
+              style={{ width: `${percentage}%` }}
+            />
           </div>
         </div>
 
@@ -120,52 +130,75 @@ export default function MaturityProgress({
 
       {/* RIGHT: User Roles Overview */}
       <div className="space-y-2">
-        <h3 className="text-lg font-semibold text-gray-800 dark:text-gray-100">Your Roles</h3>
+        <h3 className="text-lg font-semibold text-gray-800 dark:text-gray-100">
+          Your Roles
+        </h3>
         <div className="flex flex-wrap gap-2">
           {roles.map((role, idx) => (
-            <span key={idx} className="bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-100 px-3 py-1 rounded-full text-xs font-medium">
+            <span
+              key={idx}
+              className="bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-100 px-3 py-1 rounded-full text-xs font-medium"
+            >
               {getRoleByCode(role)?.name || role}
             </span>
           ))}
         </div>
         <p className="text-sm text-gray-600 dark:text-gray-400">
-          Based on your role{roles.length > 1 ? 's' : ''}, you may perform status transitions or submit evaluations.
+          Based on your role{roles.length > 1 ? 's' : ''}, you may perform
+          status transitions or submit evaluations.
         </p>
 
-
-      <button
-  onClick={() => setShowHelpModal(true)}
-  className="text-sm text-blue-600 hover:underline ml-2"
->
-  ℹ️ Learn more about statuses
-</button>
+        <button
+          onClick={() => setShowHelpModal(true)}
+          className="text-sm text-blue-600 hover:underline ml-2"
+        >
+          ℹ️ Learn more about statuses
+        </button>
       </div>
 
-        {showHelpModal && (
-            <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center">
-                <div className="bg-white dark:bg-gray-900 p-6 rounded-lg max-w-lg w-full shadow-xl">
-                <h2 className="text-lg font-semibold mb-2">Lab Status Overview</h2>
-                <p className="text-sm mb-4">Statuses reflect lifecycle stages:</p>
-                <img src="/images/lab_lifecycle.svg" alt="Lab lifecycle diagram" className="rounded border mb-4" />
-                <button
-                    onClick={() => setShowHelpModal(false)}
-                    className="text-sm bg-blue-600 text-white px-4 py-1 rounded hover:bg-blue-700"
-                >
-                    Close
-                </button>
-                </div>
-            </div>
-        )}
-    
+      {showHelpModal && (
+        <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center">
+          <div className="bg-white dark:bg-gray-900 p-6 rounded-lg max-w-lg w-full shadow-xl">
+            <h2 className="text-lg font-semibold mb-2">Lab Status Overview</h2>
+            <p className="text-sm mb-4">Statuses reflect lifecycle stages:</p>
+            <img
+              src="/images/lab_lifecycle.svg"
+              alt="Lab lifecycle diagram"
+              className="rounded border mb-4"
+            />
+            <button
+              onClick={() => setShowHelpModal(false)}
+              className="text-sm bg-blue-600 text-white px-4 py-1 rounded hover:bg-blue-700"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      )}
+
       {/* Evaluation Confirmation Modal */}
       {showEvalModal && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
           <div className="bg-white dark:bg-gray-800 p-6 rounded shadow-xl w-full max-w-sm">
-            <h3 className="text-lg font-semibold mb-4">Confirm Evaluation Request</h3>
-            <p className="text-sm mb-4">Are you sure you want to request an evaluation for Level {level}?</p>
+            <h3 className="text-lg font-semibold mb-4">
+              Confirm Evaluation Request
+            </h3>
+            <p className="text-sm mb-4">
+              Are you sure you want to request an evaluation for Level {level}?
+            </p>
             <div className="flex justify-end gap-2">
-              <button onClick={() => setShowEvalModal(false)} className="text-sm px-3 py-1 border border-gray-400 rounded">Cancel</button>
-              <button onClick={() => updateLevel(level, 200)} className="text-sm px-3 py-1 bg-blue-600 text-white rounded">Confirm</button>
+              <button
+                onClick={() => setShowEvalModal(false)}
+                className="text-sm px-3 py-1 border border-gray-400 rounded"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => updateLevel(level, 200)}
+                className="text-sm px-3 py-1 bg-blue-600 text-white rounded"
+              >
+                Confirm
+              </button>
             </div>
           </div>
         </div>
@@ -175,11 +208,26 @@ export default function MaturityProgress({
       {showReevalModal && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
           <div className="bg-white dark:bg-gray-800 p-6 rounded shadow-xl w-full max-w-sm">
-            <h3 className="text-lg font-semibold mb-4">Confirm Re-evaluation Request</h3>
-            <p className="text-sm mb-4">Are you sure you want to request a re-evaluation for Level {level}?</p>
+            <h3 className="text-lg font-semibold mb-4">
+              Confirm Re-evaluation Request
+            </h3>
+            <p className="text-sm mb-4">
+              Are you sure you want to request a re-evaluation for Level {level}
+              ?
+            </p>
             <div className="flex justify-end gap-2">
-              <button onClick={() => setShowReevalModal(false)} className="text-sm px-3 py-1 border border-gray-400 rounded">Cancel</button>
-              <button onClick={() => updateLevel(level, 203)} className="text-sm px-3 py-1 bg-blue-600 text-white rounded">Confirm</button>
+              <button
+                onClick={() => setShowReevalModal(false)}
+                className="text-sm px-3 py-1 border border-gray-400 rounded"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => updateLevel(level, 203)}
+                className="text-sm px-3 py-1 bg-blue-600 text-white rounded"
+              >
+                Confirm
+              </button>
             </div>
           </div>
         </div>
@@ -196,20 +244,28 @@ export default function MaturityProgress({
               onChange={(e) => setSelectedStatus(Number(e.target.value))}
             >
               {Object.entries(LabLevelStatuses).map(([code, name]) => (
-                <option key={code} value={code}>{name}</option>
+                <option key={code} value={code}>
+                  {name}
+                </option>
               ))}
             </select>
             <div className="flex justify-end gap-2">
-              <button onClick={() => setShowStatusModal(false)} className="text-sm px-3 py-1 border border-gray-400 rounded">Cancel</button>
-              <button onClick={() => updateLevel(level, selectedStatus)} className="text-sm px-3 py-1 bg-purple-600 text-white rounded">Update</button>
+              <button
+                onClick={() => setShowStatusModal(false)}
+                className="text-sm px-3 py-1 border border-gray-400 rounded"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => updateLevel(level, selectedStatus)}
+                className="text-sm px-3 py-1 bg-purple-600 text-white rounded"
+              >
+                Update
+              </button>
             </div>
           </div>
         </div>
       )}
-
-      
     </section>
-
-    
   );
 }

--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -1,7 +1,7 @@
-"use client";
+'use client';
 
-import { useContext } from "react";
-import { AuthContext } from "@app/context/AuthContext";
+import { useContext } from 'react';
+import { AuthContext } from '@app/context/AuthContext';
 
 export default function Navbar() {
   const { user, logout } = useContext(AuthContext);
@@ -15,9 +15,11 @@ export default function Navbar() {
           <div className="flex flex-col sm:flex-row items-end sm:items-center gap-2 text-sm text-right">
             <div className="sm:text-left space-y-0.5">
               <div>{user.name}</div>
-              <div className="text-gray-500 dark:text-gray-400">{user.email}</div>
+              <div className="text-gray-500 dark:text-gray-400">
+                {user.email}
+              </div>
               <div className="text-xs text-indigo-500 dark:text-indigo-400">
-                {user.roles.slice(0, 3).join(", ")}
+                {user.roles.slice(0, 3).join(', ')}
               </div>
             </div>
             <button

--- a/src/app/components/RequestReviewPage.tsx
+++ b/src/app/components/RequestReviewPage.tsx
@@ -1,7 +1,7 @@
-"use client";
+'use client';
 
-import { useEffect, useState } from "react";
-import { API_BASE_URL } from "@app/constants/config";
+import { useEffect, useState } from 'react';
+import { API_BASE_URL } from '@app/constants/config';
 
 export enum RequestStatus {
   Undefined = 0,
@@ -12,18 +12,18 @@ export enum RequestStatus {
 }
 
 const statusLabels: Record<RequestStatus, string> = {
-  [RequestStatus.Undefined]: "Undefined",
-  [RequestStatus.Submitted]: "Submitted",
-  [RequestStatus.UnderReview]: "Under Review",
-  [RequestStatus.Approved]: "Approved",
-  [RequestStatus.Rejected]: "Rejected",
+  [RequestStatus.Undefined]: 'Undefined',
+  [RequestStatus.Submitted]: 'Submitted',
+  [RequestStatus.UnderReview]: 'Under Review',
+  [RequestStatus.Approved]: 'Approved',
+  [RequestStatus.Rejected]: 'Rejected',
 };
 
 export default function RequestReviewPage({ id }: { id: string }) {
   const [request, setRequest] = useState<any>(null);
   const [users, setUsers] = useState<any[]>([]);
   const [roles, setRoles] = useState<any[]>([]);
-  const [comment, setComment] = useState("");
+  const [comment, setComment] = useState('');
   const [status, setStatus] = useState<RequestStatus>(RequestStatus.Submitted);
 
   useEffect(() => {
@@ -35,25 +35,30 @@ export default function RequestReviewPage({ id }: { id: string }) {
         setComment(data.comments);
       });
 
-    fetch(`${API_BASE_URL}/users`).then(res => res.json()).then(setUsers);
-    fetch(`${API_BASE_URL}/roles`).then(res => res.json()).then(setRoles);
+    fetch(`${API_BASE_URL}/users`)
+      .then((res) => res.json())
+      .then(setUsers);
+    fetch(`${API_BASE_URL}/roles`)
+      .then((res) => res.json())
+      .then(setRoles);
   }, [id]);
 
-  const getUser = (uid: string) => users.find(u => u.id === uid);
-  const getRoleName = (code: string) => roles.find(r => r.code === code)?.name || code;
+  const getUser = (uid: string) => users.find((u) => u.id === uid);
+  const getRoleName = (code: string) =>
+    roles.find((r) => r.code === code)?.name || code;
 
   const handleSubmit = async () => {
-    const reviewer = localStorage.getItem("user_id") || users[0]?._id; // Replace with real user session
+    const reviewer = localStorage.getItem('user_id') || users[0]?._id; // Replace with real user session
     await fetch(`${API_BASE_URL}/request/labs/${id}/update`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         status,
         reviewer_user_id: reviewer,
         comments: comment,
       }),
     });
-    alert("Request status updated.");
+    alert('Request status updated.');
   };
 
   if (!request) return <div>Loading...</div>;
@@ -65,22 +70,30 @@ export default function RequestReviewPage({ id }: { id: string }) {
       <section className="space-y-2">
         <div>
           <label className="block text-sm font-medium">Title</label>
-          <div className="p-2 border rounded bg-gray-50 dark:bg-gray-800">{request.title}</div>
+          <div className="p-2 border rounded bg-gray-50 dark:bg-gray-800">
+            {request.title}
+          </div>
         </div>
 
         <div>
           <label className="block text-sm font-medium">Alias</label>
-          <div className="p-2 border rounded bg-gray-50 dark:bg-gray-800">{request.alias}</div>
+          <div className="p-2 border rounded bg-gray-50 dark:bg-gray-800">
+            {request.alias}
+          </div>
         </div>
 
         <div>
           <label className="block text-sm font-medium">Scope</label>
-          <div className="p-2 border rounded bg-gray-50 dark:bg-gray-800 whitespace-pre-wrap">{request.scope}</div>
+          <div className="p-2 border rounded bg-gray-50 dark:bg-gray-800 whitespace-pre-wrap">
+            {request.scope}
+          </div>
         </div>
 
         <div>
           <label className="block text-sm font-medium">Time Plan</label>
-          <div className="p-2 border rounded bg-gray-50 dark:bg-gray-800 whitespace-pre-wrap">{request.timeplan}</div>
+          <div className="p-2 border rounded bg-gray-50 dark:bg-gray-800 whitespace-pre-wrap">
+            {request.timeplan}
+          </div>
         </div>
 
         <div>
@@ -90,8 +103,11 @@ export default function RequestReviewPage({ id }: { id: string }) {
               const user = getUser(u.user_id);
               return (
                 <li key={u._id}>
-                  <span className="font-medium">{user?.name || u.user_id}</span> ({user?.email})<br />
-                  <span className="text-sm text-gray-600">Roles: {u.role_codes.map(getRoleName).join(", ")}</span>
+                  <span className="font-medium">{user?.name || u.user_id}</span>{' '}
+                  ({user?.email})<br />
+                  <span className="text-sm text-gray-600">
+                    Roles: {u.role_codes.map(getRoleName).join(', ')}
+                  </span>
                 </li>
               );
             })}
@@ -101,14 +117,18 @@ export default function RequestReviewPage({ id }: { id: string }) {
 
       <section className="space-y-4">
         <div>
-          <label className="block text-sm font-medium">Update Request Status</label>
+          <label className="block text-sm font-medium">
+            Update Request Status
+          </label>
           <select
             value={status}
             onChange={(e) => setStatus(Number(e.target.value))}
             className="w-full mt-1 p-2 border rounded bg-white dark:bg-gray-700 dark:text-white"
           >
             {Object.entries(statusLabels).map(([key, label]) => (
-              <option key={key} value={key}>{label}</option>
+              <option key={key} value={key}>
+                {label}
+              </option>
             ))}
           </select>
         </div>

--- a/src/app/constants/config.ts
+++ b/src/app/constants/config.ts
@@ -1,5 +1,8 @@
-export const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:3000';
-export const KEYCLOAK_BASE_URL = process.env.NEXT_PUBLIC_KEYCLOAK_BASE_URL ?? 'http://localhost:8080';
-export const APP_BASE_URL = process.env.NEXT_PUBLIC_APP_BASE_URL ?? 'http://localhost:4000';
+export const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:3000';
+export const KEYCLOAK_BASE_URL =
+  process.env.NEXT_PUBLIC_KEYCLOAK_BASE_URL ?? 'http://localhost:8080';
+export const APP_BASE_URL =
+  process.env.NEXT_PUBLIC_APP_BASE_URL ?? 'http://localhost:4000';
 export const KEYCLOAK_AUTH_URL = `${KEYCLOAK_BASE_URL}/realms/vre/protocol/openid-connect/auth`;
 export const KEYCLOAK_LOGOUT_URL = `${KEYCLOAK_BASE_URL}/realms/vre/protocol/openid-connect/logout`;

--- a/src/app/constants/exitCondition.ts
+++ b/src/app/constants/exitCondition.ts
@@ -45,7 +45,7 @@ export const exitConditionStatuses: Record<number, string> = {
 //     //Development
 //     InProgress = 100,
 //     Blocked = 101,
-    
+
 //     //Evaluation
 //     RequestedEvaluation = 200,
 //     UnderEvalutaion = 201,

--- a/src/app/context/AuthContext.tsx
+++ b/src/app/context/AuthContext.tsx
@@ -1,9 +1,9 @@
-"use client";
+'use client';
 
-import React, { createContext, useEffect, useState } from "react";
-import keycloak from "../lib/auth";
-import { initializeRoleCache } from "@app/lib/roles";
-import { API_BASE_URL } from "@app/constants/config";
+import React, { createContext, useEffect, useState } from 'react';
+import keycloak from '../lib/auth';
+import { initializeRoleCache } from '@app/lib/roles';
+import { API_BASE_URL } from '@app/constants/config';
 
 interface AuthContextType {
   keycloak: Keycloak.KeycloakInstance | null;
@@ -18,7 +18,6 @@ interface AuthContextType {
   logout: () => void;
 }
 
-
 export const AuthContext = createContext<AuthContextType>({
   keycloak: null,
   initialized: false,
@@ -27,36 +26,34 @@ export const AuthContext = createContext<AuthContextType>({
 });
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const [initialized, setInitialized] = useState(false);
-  const [user, setUser] = useState<AuthContextType["user"]>(null);
+  const [user, setUser] = useState<AuthContextType['user']>(null);
 
   useEffect(() => {
-  keycloak
-    .init({ onLoad: 'login-required', checkLoginIframe: false })
-    .then(async (authenticated) => {
-      if (authenticated && keycloak.tokenParsed) {
-        const { name, email, resource_access, sub } = keycloak.tokenParsed;
+    keycloak
+      .init({ onLoad: 'login-required', checkLoginIframe: false })
+      .then(async (authenticated) => {
+        if (authenticated && keycloak.tokenParsed) {
+          const { name, email, resource_access, sub } = keycloak.tokenParsed;
 
-        const clientRoles =
-          resource_access?.['nextjs-frontend']?.roles || [];
+          const clientRoles = resource_access?.['nextjs-frontend']?.roles || [];
 
-        await initializeRoleCache();
+          await initializeRoleCache();
 
-        const res = await fetch(`${API_BASE_URL}/user-by-reference/${sub}`);
-        if (!res.ok) throw new Error('Failed to fetch user');
-  
-        setUser({
-          name: name || 'Unknown',
-          email: email || 'No email',
-          roles: clientRoles,
-          id: sub,
-          app_id: (await res.json()).id,
-        });
-      }
+          const res = await fetch(`${API_BASE_URL}/user-by-reference/${sub}`);
+          if (!res.ok) throw new Error('Failed to fetch user');
 
-      setInitialized(true);
-    });
-}, []);
+          setUser({
+            name: name || 'Unknown',
+            email: email || 'No email',
+            roles: clientRoles,
+            id: sub,
+            app_id: (await res.json()).id,
+          });
+        }
 
+        setInitialized(true);
+      });
+  }, []);
 
   const logout = () => {
     setUser(null); // clear local state

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 
 :root {
   --background: #ffffff;

--- a/src/app/labs/[id]/LabLoader.tsx
+++ b/src/app/labs/[id]/LabLoader.tsx
@@ -6,7 +6,6 @@ import { API_BASE_URL } from '@app/constants/config';
 import LabView from '@app/components/LabView';
 import { VirtualLabViewModel } from '@app/types/lab/viewModels';
 
-
 export default function LabLoader({ id }: { id: string }) {
   const { keycloak } = useContext(AuthContext);
   const [lab, setLab] = useState<VirtualLabViewModel | null>(null);
@@ -52,7 +51,7 @@ export default function LabLoader({ id }: { id: string }) {
             assignedAt: u.assigned_at,
             reference_id: u.reference_id,
             name: u.name,
-            email: u.email
+            email: u.email,
           })),
         };
 

--- a/src/app/labs/by/user/page.tsx
+++ b/src/app/labs/by/user/page.tsx
@@ -1,34 +1,34 @@
-"use client";
+'use client';
 
-import { useContext, useEffect, useState } from "react";
-import { AuthContext } from "@app/context/AuthContext";
-import { API_BASE_URL } from "@app/constants/config";
-import Link from "next/link";
+import { useContext, useEffect, useState } from 'react';
+import { AuthContext } from '@app/context/AuthContext';
+import { API_BASE_URL } from '@app/constants/config';
+import Link from 'next/link';
 
 const LabLevelStatuses: Record<number, string> = {
-  0: "Undefined",
-  100: "In Development",
-  101: "Blocked",
-  200: "Requested Evaluation",
-  201: "Under Evaluation",
-  202: "Needs Improvements",
-  203: "Requested re-Evaluation",
-  300: "Completed",
+  0: 'Undefined',
+  100: 'In Development',
+  101: 'Blocked',
+  200: 'Requested Evaluation',
+  201: 'Under Evaluation',
+  202: 'Needs Improvements',
+  203: 'Requested re-Evaluation',
+  300: 'Completed',
 };
 
 const roleActions: Record<string, Record<number, string>> = {
   CRD: {
-    200: "Review evaluation request",
-    201: "Evaluate lab",
-    203: "Review re-evaluation request",
+    200: 'Review evaluation request',
+    201: 'Evaluate lab',
+    203: 'Review re-evaluation request',
   },
   VLD: {
-    100: "Request evaluation",
-    202: "Request re-evaluation",
+    100: 'Request evaluation',
+    202: 'Request re-evaluation',
   },
   GLU: {
-    100: "Request evaluation",
-    202: "Request re-evaluation",
+    100: 'Request evaluation',
+    202: 'Request re-evaluation',
   },
 };
 
@@ -43,7 +43,7 @@ interface LabSummary {
 export default function LabsByRolePage() {
   const { user } = useContext(AuthContext);
   const [labs, setLabs] = useState<LabSummary[]>([]);
-  const [roleCode, setRoleCode] = useState("CRD");
+  const [roleCode, setRoleCode] = useState('CRD');
 
   useEffect(() => {
     if (!user?.id || !roleCode) return;
@@ -77,7 +77,7 @@ export default function LabsByRolePage() {
       ) : (
         <div className="grid gap-4">
           {labs.map((lab) => {
-            const statusLabel = LabLevelStatuses[lab.level_state] || "Unknown";
+            const statusLabel = LabLevelStatuses[lab.level_state] || 'Unknown';
             const actionHint = roleActions[roleCode]?.[lab.level_state];
             return (
               <Link
@@ -86,8 +86,12 @@ export default function LabsByRolePage() {
                 className="block border rounded p-4 hover:shadow transition cursor-pointer bg-white dark:bg-gray-800"
               >
                 <h2 className="text-lg font-semibold">{lab.name}</h2>
-                <p className="text-sm text-gray-500 dark:text-gray-300">Alias: {lab.alias}</p>
-                <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">Status: <strong>{statusLabel}</strong></p>
+                <p className="text-sm text-gray-500 dark:text-gray-300">
+                  Alias: {lab.alias}
+                </p>
+                <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+                  Status: <strong>{statusLabel}</strong>
+                </p>
                 {actionHint && (
                   <p className="text-sm text-blue-700 dark:text-blue-400 mt-2 italic">
                     Action required: {actionHint}

--- a/src/app/labs/history/graph/page.tsx
+++ b/src/app/labs/history/graph/page.tsx
@@ -1,14 +1,14 @@
-"use client";
+'use client';
 
-import { useEffect, useState } from "react";
-import { API_BASE_URL } from "@app/constants/config";
+import { useEffect, useState } from 'react';
+import { API_BASE_URL } from '@app/constants/config';
 import {
   GraphCanvas,
   GraphNode,
   GraphEdge,
   NodePositionArgs,
-  InternalGraphPosition
-} from "reagraph";
+  InternalGraphPosition,
+} from 'reagraph';
 
 interface BackendNode {
   id: string;
@@ -34,31 +34,40 @@ export default function LabHistoryGraph() {
     fetch(`${API_BASE_URL}/lab/dependencies/graph`)
       .then((res) => res.json())
       .then((data) => {
-        const mappedNodes: LabGraphNode[] = data.nodes.map((n: BackendNode) => ({
-          id: n.id,
-          label: n.label,
-          subLabel: `Level ${n.level}`,
-          fill: getLevelColor(n.level),
-          labId: n.labId || n.id.split("-")[0] // fallback if labId is not provided
-        }));
+        const mappedNodes: LabGraphNode[] = data.nodes.map(
+          (n: BackendNode) => ({
+            id: n.id,
+            label: n.label,
+            subLabel: `Level ${n.level}`,
+            fill: getLevelColor(n.level),
+            labId: n.labId || n.id.split('-')[0], // fallback if labId is not provided
+          }),
+        );
 
         const mappedEdges: GraphEdge[] = data.edges.map((e: BackendEdge) => ({
           source: e.from,
           target: e.to,
           id: `${e.from}-${e.to}`,
-          label: `${e.from}-${e.to}`
+          label: `${e.from}-${e.to}`,
         }));
 
         setNodes(mappedNodes);
         setEdges(mappedEdges);
 
-        console.log("Graph data loaded:", { nodes: mappedNodes, edges: mappedEdges, data });
+        console.log('Graph data loaded:', {
+          nodes: mappedNodes,
+          edges: mappedEdges,
+          data,
+        });
       })
       .catch(console.error);
   }, []);
 
-  const getNodePosition = (id: string, { nodes }: NodePositionArgs): InternalGraphPosition => {
-    const currentNode = nodes.find(n => n.id === id) as LabGraphNode;
+  const getNodePosition = (
+    id: string,
+    { nodes }: NodePositionArgs,
+  ): InternalGraphPosition => {
+    const currentNode = nodes.find((n) => n.id === id) as LabGraphNode;
     if (!currentNode) {
       return {
         id,
@@ -67,20 +76,22 @@ export default function LabHistoryGraph() {
         z: 1,
         index: 0,
         data: undefined,
-        links: []
+        links: [],
       };
     }
 
     // Group nodes by labId
     const labGroups: Record<string, LabGraphNode[]> = {};
-    (nodes as LabGraphNode[]).forEach(node => {
+    (nodes as LabGraphNode[]).forEach((node) => {
       if (!labGroups[node.labId]) labGroups[node.labId] = [];
       labGroups[node.labId].push(node);
     });
 
     const labOrder = Object.keys(labGroups);
     const groupIndex = labOrder.indexOf(currentNode.labId);
-    const nodeIndex = labGroups[currentNode.labId].findIndex(n => n.id === id);
+    const nodeIndex = labGroups[currentNode.labId].findIndex(
+      (n) => n.id === id,
+    );
 
     return {
       id,
@@ -89,7 +100,7 @@ export default function LabHistoryGraph() {
       z: 1,
       index: nodeIndex,
       data: currentNode,
-      links: []
+      links: [],
     };
   };
 
@@ -108,6 +119,6 @@ export default function LabHistoryGraph() {
 }
 
 function getLevelColor(level: number): string {
-  const palette = ["#f87171", "#fb923c", "#facc15", "#4ade80", "#60a5fa"];
-  return palette[level] || "#a3a3a3";
+  const palette = ['#f87171', '#fb923c', '#facc15', '#4ade80', '#60a5fa'];
+  return palette[level] || '#a3a3a3';
 }

--- a/src/app/labs/propose/page.tsx
+++ b/src/app/labs/propose/page.tsx
@@ -1,8 +1,8 @@
-"use client";
+'use client';
 
-import { useEffect, useState, useContext } from "react";
-import { AuthContext } from "@app/context/AuthContext";
-import { API_BASE_URL } from "@app/constants/config";
+import { useEffect, useState, useContext } from 'react';
+import { AuthContext } from '@app/context/AuthContext';
+import { API_BASE_URL } from '@app/constants/config';
 
 interface Lab {
   id: string;
@@ -20,35 +20,39 @@ interface User {
 
 export default function ProposeLabPage() {
   const { user } = useContext(AuthContext);
-  const [title, setTitle] = useState("");
-  const [alias, setAlias] = useState("");
-  const [scope, setScope] = useState("");
-  const [timePlan, setTimePlan] = useState("");
+  const [title, setTitle] = useState('');
+  const [alias, setAlias] = useState('');
+  const [scope, setScope] = useState('');
+  const [timePlan, setTimePlan] = useState('');
   const [developers, setDevelopers] = useState<string[]>([]);
-  const [goldenUser, setGoldenUser] = useState<string>("");
-  const [sourceLab, setSourceLab] = useState<string>("");
-  const [sourceLevel, setSourceLevel] = useState<number | "">("");
+  const [goldenUser, setGoldenUser] = useState<string>('');
+  const [sourceLab, setSourceLab] = useState<string>('');
+  const [sourceLevel, setSourceLevel] = useState<number | ''>('');
 
   const [users, setUsers] = useState<User[]>([]);
   const [labs, setLabs] = useState<Lab[]>([]);
 
   useEffect(() => {
-    fetch(`${API_BASE_URL}/users`).then(res => res.json()).then(setUsers);
-    fetch(`${API_BASE_URL}/lab/list`).then(res => res.json()).then(setLabs);
+    fetch(`${API_BASE_URL}/users`)
+      .then((res) => res.json())
+      .then(setUsers);
+    fetch(`${API_BASE_URL}/lab/list`)
+      .then((res) => res.json())
+      .then(setLabs);
   }, []);
 
   const handleDeveloperToggle = (id: string) => {
-    setDevelopers(prev => {
+    setDevelopers((prev) => {
       const exists = prev.includes(id);
-      return exists ? prev.filter(uid => uid !== id) : [...prev, id];
+      return exists ? prev.filter((uid) => uid !== id) : [...prev, id];
     });
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const associated_users = [
-      { user_id: goldenUser, role_codes: ["GLU"] },
-      ...developers.map(devId => ({ user_id: devId, role_codes: ["VLD"] }))
+      { user_id: goldenUser, role_codes: ['GLU'] },
+      ...developers.map((devId) => ({ user_id: devId, role_codes: ['VLD'] })),
     ];
 
     const payload: any = {
@@ -59,20 +63,23 @@ export default function ProposeLabPage() {
       associated_users,
     };
 
-    if (sourceLab && sourceLevel !== "") {
-      payload.lab_reference = { lab_id: sourceLab, lab_level: Number(sourceLevel) };
+    if (sourceLab && sourceLevel !== '') {
+      payload.lab_reference = {
+        lab_id: sourceLab,
+        lab_level: Number(sourceLevel),
+      };
     }
 
     await fetch(`${API_BASE_URL}/request/labs/create`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
 
-    alert("Lab proposal submitted successfully!");
+    alert('Lab proposal submitted successfully!');
   };
 
-  const selectedLab = labs.find(l => l.id === sourceLab);
+  const selectedLab = labs.find((l) => l.id === sourceLab);
 
   return (
     <form onSubmit={handleSubmit} className="max-w-2xl mx-auto p-4 space-y-6">
@@ -83,7 +90,7 @@ export default function ProposeLabPage() {
           <label className="block text-sm font-medium">Title</label>
           <input
             value={title}
-            onChange={e => setTitle(e.target.value)}
+            onChange={(e) => setTitle(e.target.value)}
             className="w-full mt-1 p-2 border rounded bg-white dark:bg-gray-700 dark:text-white"
             required
           />
@@ -93,7 +100,7 @@ export default function ProposeLabPage() {
           <label className="block text-sm font-medium">Alias</label>
           <input
             value={alias}
-            onChange={e => setAlias(e.target.value)}
+            onChange={(e) => setAlias(e.target.value)}
             className="w-full mt-1 p-2 border rounded bg-white dark:bg-gray-700 dark:text-white"
             required
           />
@@ -102,10 +109,12 @@ export default function ProposeLabPage() {
 
       <div>
         <label className="block text-sm font-medium">Scope</label>
-        <p className="text-xs text-gray-500 mb-1">Describe why this lab is needed, its goals, or motivation.</p>
+        <p className="text-xs text-gray-500 mb-1">
+          Describe why this lab is needed, its goals, or motivation.
+        </p>
         <textarea
           value={scope}
-          onChange={e => setScope(e.target.value)}
+          onChange={(e) => setScope(e.target.value)}
           className="w-full mt-1 p-2 border rounded bg-white dark:bg-gray-700 dark:text-white"
           rows={3}
         />
@@ -113,10 +122,12 @@ export default function ProposeLabPage() {
 
       <div>
         <label className="block text-sm font-medium">Time Plan</label>
-        <p className="text-xs text-gray-500 mb-1">Describe when and how the lab is expected to be completed.</p>
+        <p className="text-xs text-gray-500 mb-1">
+          Describe when and how the lab is expected to be completed.
+        </p>
         <textarea
           value={timePlan}
-          onChange={e => setTimePlan(e.target.value)}
+          onChange={(e) => setTimePlan(e.target.value)}
           className="w-full mt-1 p-2 border rounded bg-white dark:bg-gray-700 dark:text-white"
           rows={3}
         />
@@ -126,12 +137,12 @@ export default function ProposeLabPage() {
         <label className="block text-sm font-medium">Golden User</label>
         <select
           value={goldenUser}
-          onChange={e => setGoldenUser(e.target.value)}
+          onChange={(e) => setGoldenUser(e.target.value)}
           className="w-full mt-1 p-2 border rounded bg-white dark:bg-gray-700 dark:text-white"
           required
         >
           <option value="">-- Select Golden User --</option>
-          {users.map(u => (
+          {users.map((u) => (
             <option key={u._id || u.id} value={u._id || u.id}>
               {u.name} ({u.email})
             </option>
@@ -142,32 +153,42 @@ export default function ProposeLabPage() {
       <div>
         <label className="block text-sm font-medium">Developers</label>
         <div className="mt-2 space-y-1 max-h-40 overflow-y-auto border p-2 rounded">
-          {users.map(user => (
-            <label key={user._id || user.id} className="flex items-center gap-2 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800">
+          {users.map((user) => (
+            <label
+              key={user._id || user.id}
+              className="flex items-center gap-2 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800"
+            >
               <input
                 type="checkbox"
                 checked={developers.includes(user._id || user.id)}
                 onChange={() => handleDeveloperToggle(user._id || user.id)}
               />
-              <span className="text-sm">{user.name} ({user.email})</span>
+              <span className="text-sm">
+                {user.name} ({user.email})
+              </span>
             </label>
           ))}
         </div>
       </div>
 
       <div>
-        <label className="block text-sm font-medium">Based on Existing Lab</label>
-        <p className="text-xs text-gray-500 mb-2">This is optional. If selected, the new lab will be a clone of the chosen one at the selected level.</p>
+        <label className="block text-sm font-medium">
+          Based on Existing Lab
+        </label>
+        <p className="text-xs text-gray-500 mb-2">
+          This is optional. If selected, the new lab will be a clone of the
+          chosen one at the selected level.
+        </p>
         <select
           value={sourceLab}
-          onChange={e => {
+          onChange={(e) => {
             setSourceLab(e.target.value);
-            setSourceLevel("");
+            setSourceLevel('');
           }}
           className="w-full mt-1 p-2 border rounded bg-white dark:bg-gray-700 dark:text-white"
         >
           <option value="">-- Select a Lab --</option>
-          {labs.map(lab => (
+          {labs.map((lab) => (
             <option key={lab.id} value={lab.id}>
               {lab.name} ({lab.alias})
             </option>

--- a/src/app/labs/requests/[id]/page.tsx
+++ b/src/app/labs/requests/[id]/page.tsx
@@ -1,7 +1,7 @@
-"use client";
+'use client';
 
-import { useParams } from "next/navigation";
-import RequestReviewPage from "@app/components/RequestReviewPage";
+import { useParams } from 'next/navigation';
+import RequestReviewPage from '@app/components/RequestReviewPage';
 
 export default function RequestPageWrapper() {
   const params = useParams();

--- a/src/app/labs/requests/page.tsx
+++ b/src/app/labs/requests/page.tsx
@@ -1,9 +1,9 @@
-"use client";
+'use client';
 
-import { useContext, useEffect, useState } from "react";
-import { AuthContext } from "@app/context/AuthContext";
-import { API_BASE_URL } from "@app/constants/config";
-import Link from "next/link";
+import { useContext, useEffect, useState } from 'react';
+import { AuthContext } from '@app/context/AuthContext';
+import { API_BASE_URL } from '@app/constants/config';
+import Link from 'next/link';
 
 export enum RequestStatus {
   Undefined = 0,
@@ -14,11 +14,11 @@ export enum RequestStatus {
 }
 
 const statusLabels: Record<RequestStatus, string> = {
-  [RequestStatus.Undefined]: "Undefined",
-  [RequestStatus.Submitted]: "Submitted",
-  [RequestStatus.UnderReview]: "Under Review",
-  [RequestStatus.Approved]: "Approved",
-  [RequestStatus.Rejected]: "Rejected",
+  [RequestStatus.Undefined]: 'Undefined',
+  [RequestStatus.Submitted]: 'Submitted',
+  [RequestStatus.UnderReview]: 'Under Review',
+  [RequestStatus.Approved]: 'Approved',
+  [RequestStatus.Rejected]: 'Rejected',
 };
 
 export default function RequestListPage() {
@@ -29,21 +29,31 @@ export default function RequestListPage() {
 
   useEffect(() => {
     const url = `${API_BASE_URL}/request/labs${showAll ? '?show_all=true' : ''}`;
-    fetch(url).then(res => res.json()).then(setRequests);
-    fetch(`${API_BASE_URL}/users`).then(res => res.json()).then(setUsers);
+    fetch(url)
+      .then((res) => res.json())
+      .then(setRequests);
+    fetch(`${API_BASE_URL}/users`)
+      .then((res) => res.json())
+      .then(setUsers);
   }, [showAll]);
 
-  const isReviewer = user?.roles.includes("vre_lab_reviewer");
-  const getUserName = (uid: string) => users.find(u => u._id === uid)?.name || uid;
+  const isReviewer = user?.roles.includes('vre_lab_reviewer');
+  const getUserName = (uid: string) =>
+    users.find((u) => u._id === uid)?.name || uid;
 
-  if (!isReviewer) return <div className="p-6 text-red-600">You do not have permission to view this page.</div>;
+  if (!isReviewer)
+    return (
+      <div className="p-6 text-red-600">
+        You do not have permission to view this page.
+      </div>
+    );
 
   return (
     <div className="max-w-4xl mx-auto p-6 space-y-4">
       <div className="flex justify-between items-center">
         <h1 className="text-2xl font-bold">Lab Requests</h1>
         <button
-          onClick={() => setShowAll(prev => !prev)}
+          onClick={() => setShowAll((prev) => !prev)}
           className="text-sm text-blue-600 hover:underline"
         >
           {showAll ? 'Show Pending Only' : 'Show All Requests'}
@@ -55,14 +65,24 @@ export default function RequestListPage() {
       ) : (
         <ul className="space-y-3">
           {requests.map((req) => (
-            <li key={req._id} className="border rounded p-4 hover:shadow transition">
+            <li
+              key={req._id}
+              className="border rounded p-4 hover:shadow transition"
+            >
               <div className="flex justify-between items-center">
                 <div>
                   <h2 className="text-lg font-semibold">{req.title}</h2>
                   <p className="text-sm text-gray-600">Alias: {req.alias}</p>
-                  <p className="text-sm text-gray-600">Status: {statusLabels[req.status as RequestStatus]}</p>
+                  <p className="text-sm text-gray-600">
+                    Status: {statusLabels[req.status as RequestStatus]}
+                  </p>
                   <p className="text-sm text-gray-600 mt-1">
-                    GLU: {getUserName(req.associated_users.find((u: any) => u.role_codes.includes("GLU"))?.user_id)}
+                    GLU:{' '}
+                    {getUserName(
+                      req.associated_users.find((u: any) =>
+                        u.role_codes.includes('GLU'),
+                      )?.user_id,
+                    )}
                   </p>
                 </div>
                 <Link

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,23 +1,22 @@
-import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
-import "./globals.css";
-import Navbar from "@app/components/Navbar"; 
+import type { Metadata } from 'next';
+import { Geist, Geist_Mono } from 'next/font/google';
+import './globals.css';
+import Navbar from '@app/components/Navbar';
 import { AuthProvider } from '@app/context/AuthContext';
 
-
 const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
+  variable: '--font-geist-sans',
+  subsets: ['latin'],
 });
 
 const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
+  variable: '--font-geist-mono',
+  subsets: ['latin'],
 });
 
 export const metadata: Metadata = {
-  title: "VL management",
-  description: "Manage VLs maturity properties",
+  title: 'VL management',
+  description: 'Manage VLs maturity properties',
 };
 
 export default function RootLayout({

--- a/src/app/lib/auth.ts
+++ b/src/app/lib/auth.ts
@@ -15,7 +15,6 @@ type User = {
   roles: string[];
 };
 
-
 function getCookie(name: string): string | null {
   const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
   return match ? decodeURIComponent(match[2]) : null;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,8 @@
-"use client";
-import { useEffect, useState, useContext } from "react";
-import { AuthContext } from "@app/context/AuthContext";
-import { API_BASE_URL } from "@app/constants/config";
-import Link from "next/link";
-
+'use client';
+import { useEffect, useState, useContext } from 'react';
+import { AuthContext } from '@app/context/AuthContext';
+import { API_BASE_URL } from '@app/constants/config';
+import Link from 'next/link';
 
 type Lab = {
   id: string;
@@ -13,11 +12,11 @@ type Lab = {
 };
 
 const levelColors = [
-  "bg-red-200 dark:bg-red-900/40 border-red-300",
-  "bg-orange-200 dark:bg-orange-900/40 border-orange-300",
-  "bg-yellow-200 dark:bg-yellow-900/40 border-yellow-300",
-  "bg-green-200 dark:bg-green-900/40 border-green-300",
-  "bg-blue-200 dark:bg-blue-900/40 border-blue-300",
+  'bg-red-200 dark:bg-red-900/40 border-red-300',
+  'bg-orange-200 dark:bg-orange-900/40 border-orange-300',
+  'bg-yellow-200 dark:bg-yellow-900/40 border-yellow-300',
+  'bg-green-200 dark:bg-green-900/40 border-green-300',
+  'bg-blue-200 dark:bg-blue-900/40 border-blue-300',
 ];
 
 export default function Home() {
@@ -39,9 +38,12 @@ export default function Home() {
       <main className="flex flex-col gap-10 row-start-2 items-center sm:items-start max-w-4xl w-full">
         {/* Title */}
         <section className="space-y-2 text-center sm:text-left">
-          <h1 className="text-3xl font-bold">Welcome to the VL Maturity Management System</h1>
+          <h1 className="text-3xl font-bold">
+            Welcome to the VL Maturity Management System
+          </h1>
           <p className="text-base text-gray-700 dark:text-gray-300">
-            This platform helps researchers track and manage the evolution of their Virtual Research Labs (VRLs).
+            This platform helps researchers track and manage the evolution of
+            their Virtual Research Labs (VRLs).
           </p>
           <a
             href="https://naavre.net/docs/readiness_levels/"
@@ -95,59 +97,55 @@ export default function Home() {
               </a>
             ))}
           </div>
-          
-           <br></br> 
 
-
-          
+          <br></br>
         </section>
 
         <section className="w-full mt-10">
-        <h2 className="text-xl font-semibold mb-4">Lab Tools</h2>
+          <h2 className="text-xl font-semibold mb-4">Lab Tools</h2>
 
-        <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-4">
-          {/* Public: Associated Labs */}
-          <Link
-            href="/labs/by/user"
-            className="block border rounded-lg shadow p-4 text-left transition transform hover:scale-[1.02] active:scale-[.98] cursor-pointer bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600"
-          >
-            <h3 className="font-semibold text-lg">Associated Labs</h3>
-            <p className="text-xs mt-1 text-gray-800 dark:text-gray-300 italic">
-              View labs where you're assigned based on your roles.
-            </p>
-          </Link>
-
-          {/* Public: Labs History */}
-          <Link
-            href="/labs/history/graph"
-            className="block border rounded-lg shadow p-4 text-left transition transform hover:scale-[1.02] active:scale-[.98] cursor-pointer bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600"
-          >
-            <h3 className="font-semibold text-lg">View Labs History</h3>
-            <p className="text-xs mt-1 text-gray-800 dark:text-gray-300 italic">
-              Browse completed or past virtual labs and track their maturity.
-            </p>
-          </Link>
-
-          {/* Reviewer-only: Lab Requests */}
-          {is_reviewer && (
+          <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-4">
+            {/* Public: Associated Labs */}
             <Link
-              href="/labs/requests"
-              className="block border rounded-lg shadow p-4 text-left transition transform hover:scale-[1.02] active:scale-[.98] cursor-pointer bg-yellow-100 dark:bg-yellow-900/40 border-yellow-300"
+              href="/labs/by/user"
+              className="block border rounded-lg shadow p-4 text-left transition transform hover:scale-[1.02] active:scale-[.98] cursor-pointer bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600"
             >
-              <div className="flex items-center justify-between mb-1">
-                <h3 className="font-semibold text-lg">Review Lab Requests</h3>
-                <span className="text-xs bg-yellow-300 dark:bg-yellow-700 px-2 py-0.5 rounded-full text-yellow-900 dark:text-yellow-100">
-                  Reviewer
-                </span>
-              </div>
-              <p className="text-xs text-gray-800 dark:text-gray-300 italic">
-                View and approve or reject incoming VL proposals.
+              <h3 className="font-semibold text-lg">Associated Labs</h3>
+              <p className="text-xs mt-1 text-gray-800 dark:text-gray-300 italic">
+                View labs where you're assigned based on your roles.
               </p>
             </Link>
-          )}
-        </div>
-      </section>
 
+            {/* Public: Labs History */}
+            <Link
+              href="/labs/history/graph"
+              className="block border rounded-lg shadow p-4 text-left transition transform hover:scale-[1.02] active:scale-[.98] cursor-pointer bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600"
+            >
+              <h3 className="font-semibold text-lg">View Labs History</h3>
+              <p className="text-xs mt-1 text-gray-800 dark:text-gray-300 italic">
+                Browse completed or past virtual labs and track their maturity.
+              </p>
+            </Link>
+
+            {/* Reviewer-only: Lab Requests */}
+            {is_reviewer && (
+              <Link
+                href="/labs/requests"
+                className="block border rounded-lg shadow p-4 text-left transition transform hover:scale-[1.02] active:scale-[.98] cursor-pointer bg-yellow-100 dark:bg-yellow-900/40 border-yellow-300"
+              >
+                <div className="flex items-center justify-between mb-1">
+                  <h3 className="font-semibold text-lg">Review Lab Requests</h3>
+                  <span className="text-xs bg-yellow-300 dark:bg-yellow-700 px-2 py-0.5 rounded-full text-yellow-900 dark:text-yellow-100">
+                    Reviewer
+                  </span>
+                </div>
+                <p className="text-xs text-gray-800 dark:text-gray-300 italic">
+                  View and approve or reject incoming VL proposals.
+                </p>
+              </Link>
+            )}
+          </div>
+        </section>
       </main>
 
       <footer className="row-start-3 text-xs text-gray-400 dark:text-gray-500 text-center">

--- a/src/app/unauthorized/page.tsx
+++ b/src/app/unauthorized/page.tsx
@@ -1,16 +1,19 @@
-"use client";
+'use client';
 
-import { useEffect } from "react";
-import { KEYCLOAK_AUTH_URL } from "@app/constants/config";
+import { useEffect } from 'react';
+import { KEYCLOAK_AUTH_URL } from '@app/constants/config';
 
 export default function UnauthorizedPage() {
   useEffect(() => {
     const loginUrl = new URL(KEYCLOAK_AUTH_URL);
 
-    loginUrl.searchParams.set("client_id", "nextjs-frontend");
-    loginUrl.searchParams.set("redirect_uri", window.location.origin + "/callback");
-    loginUrl.searchParams.set("response_type", "code");
-    loginUrl.searchParams.set("scope", "openid");
+    loginUrl.searchParams.set('client_id', 'nextjs-frontend');
+    loginUrl.searchParams.set(
+      'redirect_uri',
+      window.location.origin + '/callback',
+    );
+    loginUrl.searchParams.set('response_type', 'code');
+    loginUrl.searchParams.set('scope', 'openid');
 
     // Delay a bit before redirecting
     setTimeout(() => {
@@ -19,7 +22,7 @@ export default function UnauthorizedPage() {
   }, []);
 
   return (
-    <div style={{ padding: "2rem", fontFamily: "sans-serif" }}>
+    <div style={{ padding: '2rem', fontFamily: 'sans-serif' }}>
       <h1>🔒 Session expired</h1>
       <p>Redirecting you to login...</p>
     </div>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -24,12 +24,14 @@ export async function middleware(request: NextRequest) {
     loginUrl.searchParams.set('scope', 'openid');
     loginUrl.searchParams.set('state', request.nextUrl.pathname); // preserve path
 
-
     return NextResponse.redirect(loginUrl);
   }
 
   try {
-    const publicKey = await importSPKI(process.env.KEYCLOAK_PUBLIC_KEY!, RS256_ALG);
+    const publicKey = await importSPKI(
+      process.env.KEYCLOAK_PUBLIC_KEY!,
+      RS256_ALG,
+    );
     const { payload } = await jwtVerify(token, publicKey);
     console.log('Verified user:', payload);
 


### PR DESCRIPTION
## Summary
- add Prettier config and ignore patterns
- hook up a `format` script in `package.json`
- format the project with Prettier

## Testing
- `npx prettier --write .`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68667702c5ac832bb9baefc71b948e9c