### PR TITLE
Adjust auth flow for public pages

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+import { useEffect } from "react";
+import keycloak from "@app/lib/auth";
+
+export default function LoginPage() {
+  useEffect(() => {
+    keycloak.login({ redirectUri: window.location.origin });
+  }, []);
+
+  return <p className="p-4">Redirecting to login...</p>;
+}


### PR DESCRIPTION
## Summary
- allow optional authentication for public pages
- add login page for manual sign-in

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6881e8c78364832b8eaa98a41d8421f4