### PR TITLE
Handle unauthenticated lab pages and forward auth token

### DIFF
--- a/src/app/components/AssignedUsers.tsx
+++ b/src/app/components/AssignedUsers.tsx
@@ -26,7 +26,7 @@ type Props = {
 };
 
 export default function AssignedUsers({ users, labId }: Props) {
-  const { user } = useContext(AuthContext);
+  const { user, keycloak } = useContext(AuthContext);
   const isAdmin = user?.roles.includes('vre_admin');
 
   const [showModal, setShowModal] = useState(false);
@@ -65,7 +65,12 @@ export default function AssignedUsers({ users, labId }: Props) {
 
       const res = await fetch(`${API_BASE_URL}/lab/${labId}/assign-users`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          ...(keycloak?.token && {
+            Authorization: `Bearer ${keycloak.token}`,
+          }),
+        },
         body: JSON.stringify(dto),
       });
 

--- a/src/app/components/ExitConditions/Card.tsx
+++ b/src/app/components/ExitConditions/Card.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useContext } from 'react';
 import { API_BASE_URL } from '@app/constants/config';
 import { ExitConditionCardProps } from '@app/components/ExitConditions/types';
 import {
   exitConditionLabels,
   exitConditionStatuses,
 } from '@app/constants/exitCondition';
+import { AuthContext } from '@app/context/AuthContext';
 
 export default function ExitConditionCard({
   cond,
@@ -14,6 +15,7 @@ export default function ExitConditionCard({
   userRoles,
 }: ExitConditionCardProps) {
   const isCoordinator = userRoles.includes('CRD');
+  const { keycloak } = useContext(AuthContext);
 
   const [showEditModal, setShowEditModal] = useState(false);
   const [showCommentModal, setShowCommentModal] = useState(false);
@@ -37,6 +39,9 @@ export default function ExitConditionCard({
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
+            ...(keycloak?.token && {
+              Authorization: `Bearer ${keycloak.token}`,
+            }),
           },
           body: JSON.stringify({
             status: selectedStatus,

--- a/src/app/components/MaturityProgress.tsx
+++ b/src/app/components/MaturityProgress.tsx
@@ -2,9 +2,10 @@
 
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import { getRoleByCode } from '@app/lib/roles';
 import { API_BASE_URL } from '@app/constants/config';
+import { AuthContext } from '@app/context/AuthContext';
 
 interface Props {
   roles: string[];
@@ -39,6 +40,7 @@ export default function MaturityProgress({
   const [showStatusModal, setShowStatusModal] = useState(false);
   const [showHelpModal, setShowHelpModal] = useState(false);
   const [selectedStatus, setSelectedStatus] = useState(levelState);
+  const { keycloak } = useContext(AuthContext);
 
   const percentage =
     totalConditions > 0
@@ -55,7 +57,12 @@ export default function MaturityProgress({
   const updateLevel = async (newLevel: number, state: number) => {
     const res = await fetch(`${API_BASE_URL}/lab/${labId}/update_level`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        ...(keycloak?.token && {
+          Authorization: `Bearer ${keycloak.token}`,
+        }),
+      },
       body: JSON.stringify({ level: newLevel, state }),
     });
 

--- a/src/app/components/RequestReviewPage.tsx
+++ b/src/app/components/RequestReviewPage.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useContext } from 'react';
 import { API_BASE_URL } from '@app/constants/config';
+import { AuthContext } from '@app/context/AuthContext';
 
 export enum RequestStatus {
   Undefined = 0,
@@ -25,6 +26,7 @@ export default function RequestReviewPage({ id }: { id: string }) {
   const [roles, setRoles] = useState<any[]>([]);
   const [comment, setComment] = useState('');
   const [status, setStatus] = useState<RequestStatus>(RequestStatus.Submitted);
+  const { keycloak } = useContext(AuthContext);
 
   useEffect(() => {
     fetch(`${API_BASE_URL}/request/labs/${id}`)
@@ -51,7 +53,12 @@ export default function RequestReviewPage({ id }: { id: string }) {
     const reviewer = localStorage.getItem('user_id') || users[0]?._id; // Replace with real user session
     await fetch(`${API_BASE_URL}/request/labs/${id}/update`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        ...(keycloak?.token && {
+          Authorization: `Bearer ${keycloak.token}`,
+        }),
+      },
       body: JSON.stringify({
         status,
         reviewer_user_id: reviewer,

--- a/src/app/labs/[id]/LabLoader.tsx
+++ b/src/app/labs/[id]/LabLoader.tsx
@@ -13,14 +13,12 @@ export default function LabLoader({ id }: { id: string }) {
 
   useEffect(() => {
     const fetchLab = async () => {
-      if (!keycloak?.token) return;
-
       try {
-        const res = await fetch(`${API_BASE_URL}/lab/${id}`, {
-          headers: {
-            Authorization: `Bearer ${keycloak.token}`,
-          },
-        });
+        const headers: Record<string, string> = {};
+        if (keycloak?.token) {
+          headers.Authorization = `Bearer ${keycloak.token}`;
+        }
+        const res = await fetch(`${API_BASE_URL}/lab/${id}`, { headers });
 
         if (!res.ok) {
           throw new Error(`Error ${res.status}: ${await res.text()}`);
@@ -62,7 +60,7 @@ export default function LabLoader({ id }: { id: string }) {
     };
 
     fetchLab();
-  }, [id, keycloak]);
+  }, [id, keycloak?.token]);
 
   if (error) return <p className="text-red-600">Error: {error}</p>;
   if (!lab) return <p>Loading...</p>;

--- a/src/app/labs/propose/page.tsx
+++ b/src/app/labs/propose/page.tsx
@@ -19,7 +19,7 @@ interface User {
 }
 
 export default function ProposeLabPage() {
-  const { user } = useContext(AuthContext);
+  const { user, keycloak } = useContext(AuthContext);
   const [title, setTitle] = useState('');
   const [alias, setAlias] = useState('');
   const [scope, setScope] = useState('');
@@ -72,7 +72,12 @@ export default function ProposeLabPage() {
 
     await fetch(`${API_BASE_URL}/request/labs/create`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        ...(keycloak?.token && {
+          Authorization: `Bearer ${keycloak.token}`,
+        }),
+      },
       body: JSON.stringify(payload),
     });
 


### PR DESCRIPTION
## Summary
- Ensure lab page fetches lab data even without auth and handles missing resources
- Attach bearer token to POST requests across components

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1cd395658832b9070137df63fdfa3