### PR TITLE
Handle users with no associated labs and filter roles client-side

### DIFF
--- a/src/app/labs/by/user/page.tsx
+++ b/src/app/labs/by/user/page.tsx
@@ -38,22 +38,59 @@ interface LabSummary {
   alias: string;
   current_level: number;
   level_state: number;
+  role_codes: string[];
+}
+
+interface ApiLab {
+  id: string;
+  name: string;
+  alias: string;
+  current_level: number;
+  level_state: number;
+  assigned_users?: {
+    user_id: string;
+    role_codes: string[];
+  }[];
 }
 
 export default function LabsByRolePage() {
   const { user } = useContext(AuthContext);
-  const [labs, setLabs] = useState<LabSummary[]>([]);
+  const [labs, setLabs] = useState<LabSummary[] | null>(null);
   const [roleCode, setRoleCode] = useState('CRD');
 
   useEffect(() => {
-    if (!user?.id || !roleCode) return;
-    fetch(`${API_BASE_URL}/lab/by-user/${user.app_id}?roleCode=${roleCode}`)
-      .then((res) => res.json())
-      .then(setLabs)
-      .catch(console.error);
-  }, [user?.id, roleCode]);
+    if (!user?.app_id) return;
+    fetch(`${API_BASE_URL}/lab/by-user/${user.app_id}`)
+      .then(async (res) => {
+        if (!res.ok) {
+          console.error('Failed to fetch labs', res.status);
+          return [];
+        }
+        return res.json();
+      })
+      .then((data) => {
+        const labsData: ApiLab[] = Array.isArray(data) ? data : [];
+        const mappedLabs: LabSummary[] = labsData.map((lab) => ({
+          id: lab.id,
+          name: lab.name,
+          alias: lab.alias,
+          current_level: lab.current_level,
+          level_state: lab.level_state,
+          role_codes:
+            lab.assigned_users?.find((u) => u.user_id === user.app_id)?.role_codes || [],
+        }));
+        setLabs(mappedLabs);
+      })
+      .catch((err) => {
+        console.error(err);
+        setLabs([]);
+      });
+  }, [user?.app_id]);
 
   if (!user) return <div className="p-4">Loading...</div>;
+
+  const filteredLabs =
+    labs?.filter((lab) => lab.role_codes.includes(roleCode)) ?? [];
 
   return (
     <div className="max-w-4xl mx-auto p-6 space-y-6">
@@ -72,11 +109,15 @@ export default function LabsByRolePage() {
         </select>
       </div>
 
-      {labs.length === 0 ? (
+      {labs === null ? (
+        <p className="text-gray-600">Loading labs...</p>
+      ) : labs.length === 0 ? (
+        <p className="text-gray-600">You are not associated with any labs.</p>
+      ) : filteredLabs.length === 0 ? (
         <p className="text-gray-600">No labs found for this role.</p>
       ) : (
         <div className="grid gap-4">
-          {labs.map((lab) => {
+          {filteredLabs.map((lab) => {
             const statusLabel = LabLevelStatuses[lab.level_state] || 'Unknown';
             const actionHint = roleActions[roleCode]?.[lab.level_state];
             return (


### PR DESCRIPTION
## Summary
- fetch all labs for a user without specifying role
- map assigned roles from backend and filter client-side, showing messages when no labs exist

## Testing
- `npm install --quiet --no-audit --no-fund` (fails: ENOTEMPTY: directory not empty, rename '/workspace/vre_levels_front/node_modules/eslint-import-resolver-node' -> '/workspace/vre_levels_front/node_modules/.eslint-import-resolver-node-wRKoE6cn')
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: sh: 1: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68a30c08d340832b80a91e682204963e